### PR TITLE
Removed docusaurus footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -55,47 +55,6 @@ const config = {
           },
         ],
       },
-      footer: {
-        style: 'dark',
-        links: [
-          {
-            title: 'Docs',
-            items: [
-              {
-                label: 'Tutorial',
-                to: '/',
-              },
-            ],
-          },
-          {
-            title: 'Community',
-            items: [
-              {
-                label: 'Stack Overflow',
-                href: 'https://stackoverflow.com/questions/tagged/docusaurus',
-              },
-              {
-                label: 'Discord',
-                href: 'https://discordapp.com/invite/docusaurus',
-              },
-              {
-                label: 'Twitter',
-                href: 'https://twitter.com/docusaurus',
-              },
-            ],
-          },
-          {
-            title: 'More',
-            items: [
-              {
-                label: 'GitHub',
-                href: 'https://github.com/facebook/docusaurus',
-              },
-            ],
-          },
-        ],
-        copyright: `Copyright © ${new Date().getFullYear()} My Project, Inc. Built with Docusaurus.`,
-      },
       colorMode: {
         defaultMode: 'dark',
       },


### PR DESCRIPTION
[TOOLS-1792](https://horizenlabs.atlassian.net/browse/TOOLS-1792)
Removed docusaurus footer

URL Preview: https://taijon-remove-footer.evm-documentation.pages.dev/