### PR TITLE
[TOOLS-1836] Add metadata to EVM documentation

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,7 +1,13 @@
 ---
 sidebar_position: 1
 slug: /
+title: Get Started
+description: Dive into the official Horizen EON documentation portal to learn how to communicate, interact, and build on Horizen’s EVM sidechain.
 ---
+
+<head>
+  <title>Horizen EON Documentation</title>
+</head>
 
 # Get Started
 


### PR DESCRIPTION
https://horizenlabs.atlassian.net/browse/TOOLS-1836

Title Tag - Horizen EON Documentation

Meta Description - Dive into the official Horizen EON documentation portal to learn how to communicate, interact, and build on Horizen’s EVM sidechain.

Preview URL: https://tools-1836.evm-documentation.pages.dev/