### PR TITLE
[WEB3-790] Google Analytics: docs.horizen.io

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -66,6 +66,10 @@ const config = {
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
         },
+        gtag: {
+          trackingID: "G-61R2LZVGSH",
+          anonymizeIP: true,
+        }
       }),
     ],
   ],


### PR DESCRIPTION
## JIRA Ticket
[Google Analytics: docs.horizen.io](https://horizenlabs.atlassian.net/browse/WEB3-790)

## Description
- Add Google Analytics to docs.horizen.io